### PR TITLE
Added support for windows paths.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ var _ = require('underscore')
   , ssh = require('./ssh')
   , url = require('url')
   , os = require('os')
-  , pathHelper = require('path')
+  , pathJoin = require('path').join
 
 var GITHUB_API_ENDPOINT = "https://api.github.com";
 
@@ -468,7 +468,7 @@ var setup_integration = exports.setup_integration = function(user_obj, gh_repo_i
   });
   var config_key = repo.html_url;
   var gh_repo_path = url.parse(repo.html_url).pathname;
-  var keyname = pathHelper.join(os.tmpdir(), user_obj.github.id + gh_repo_path.replace(/\//g, '_'));
+  var keyname = pathJoin(os.tmpdir(), user_obj.github.id + gh_repo_path.replace(/\//g, '_'));
   if (no_ssh) {
     return Step(
       function () {
@@ -563,7 +563,7 @@ var setup_integration = exports.setup_integration = function(user_obj, gh_repo_i
 var setup_integration_manual = exports.setup_integration_manual = function(req, org, github_url, callback) {
   var gh_repo_path = url.parse(github_url).pathname;
   var config_key = github_url;
-  var keyname = pathHelper.join(os.tmpdir(), gh_repo_path.replace(/\//g, '_')); // removed github.id but should still be unique
+  var keyname = pathJoin(os.tmpdir(), gh_repo_path.replace(/\//g, '_')); // removed github.id but should still be unique
   var deploy_key_title;
   var deploy_public_key;
   var webhook_url;


### PR DESCRIPTION
Used os.tmpdir instead of "/tmp/" to support windows. Also used path.join to combine the temp dir with the filename to make doubly sure it will work on both *nix and windows.
