### PR TITLE
Watch out for missing rels in Link header.

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -250,7 +250,7 @@ var pageinated_api_call = exports.pageinated_api_call = function(path, access_to
             r = parse_link_header(link);
           }
           // Stop condition: No link header or we think we just read the last page
-          if (!link || (r.next === undefined && r.first !== undefined)) {
+          if (!link || r.next === undefined) {
             callback(null, {data:_.flatten(pages), response: response});
           } else {
           // Request next page and continue


### PR DESCRIPTION
Fix for https://github.com/Strider-CD/strider/issues/413.

GitHub is sending Link headers without rel="first" or rel="next" which crashes Strider when you try to refresh your GitHub projects.

The Link header I logged right before the crash only had a rel="last". I don't know if that's just a temporary mistake on GitHub's part, but removing the check for the first link like I did in this pull request prevents Strider from crashing.

I haven't seen any other errors since I made this patch, but I'm new to Strider so might be missing a lot.
