### PR TITLE
Fix Webhook payload failed to parse as JSON issue

### DIFF
--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -198,7 +198,7 @@ function receiveWebhook(emitter, req, res) {
   console.log('got a body:', req.body)
   var payload
   try {
-    payload = JSON.parse(req.body.payload)
+    payload = req.body
   } catch (e) {
     console.error('Webhook payload failed to parse as JSON')
     return res.send(400, 'Invalid JSON in the payload')


### PR DESCRIPTION
referencing Issue https://github.com/Strider-CD/strider/issues/428#issuecomment-44067451

req.body.payload is showing up as undefined which is causing payload = JSON.parse(req.body.payload) to fail, the correct code should just be payload = req.body and it works fine, req.body at that point has already done JSON.parse(req.body.payload) at some earlier point?
