### PR TITLE
Fix authentication when user does not have a public email

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -164,7 +164,7 @@ function makeAccount(accessToken, profile) {
     config: {
       accessToken: accessToken,
       login: profile.username,
-      email: profile.emails ? profile.emails[0] : null,
+      email: profile.emails ? profile.emails[0].value : null,
       gravatarId: profile._json.gravatar_id,
       name: profile.displayName
     },


### PR DESCRIPTION
Hi there. I was running into issues when trying to authenticate my github account, and was able to track down an edge case.
Turns out the lib was expecting everyone to have a public email and was not handling a null check. 
