### PR TITLE
Bugfix: Oauth still breaks without email, prev check to replace with null didn't work

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -164,7 +164,7 @@ function makeAccount(accessToken, profile) {
     config: {
       accessToken: accessToken,
       login: profile.username,
-      email: profile.emails ? profile.emails[0].value : null,
+      email: profile.emails && profile.emails[0] ? profile.emails[0].value : null,
       gravatarId: profile._json.gravatar_id,
       name: profile.displayName
     },


### PR DESCRIPTION
Add line to check that the 0 property exists before using it, current version still breaks

Strider-CD/strider#599
Strider-CD/strider#666

I've had confirmation from a colleague that this has fixed the issue, and they have successfully deployed.
