### PR TITLE
Replace request with superagent

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -3,8 +3,6 @@
 var _ = require('lodash');
 var async = require('async');
 var debug = require('debug')('strider-github:api');
-var qs = require('querystring');
-var request = require('request');
 var Step = require('step');
 var superagent = require('superagent');
 var url = require('url');
@@ -32,11 +30,12 @@ module.exports = {
  */
 function createHooks(reponame, url, secret, token, callback) {
   var qpm = {access_token: token};
-  var post_url = GITHUB_API_ENDPOINT + '/repos/' + reponame + '/hooks?' + qs.stringify(qpm);
+  var post_url = GITHUB_API_ENDPOINT + '/repos/' + reponame + '/hooks';
   debug('CREATE WEBHOOK URL:', post_url, url);
-  request.post({
-    url: post_url,
-    body: {
+  superagent
+    .post(post_url)
+    .query(qpm)
+    .send({
       name: 'web',
       active: true,
       events: ['push', 'pull_request', 'issue_comment'],
@@ -44,20 +43,17 @@ function createHooks(reponame, url, secret, token, callback) {
         url: url,
         secret: secret
       }
-    },
-    json: true,
-    headers: {
-      'user-agent': 'StriderCD (http://stridercd.com)'
-    }
-  }, function (err, response, body) {
-    if (err) return callback(err);
-    if (response.statusCode !== 201) {
-      var badStatusErr = new Error('Bad status code: ' + response.statusCode);
-      badStatusErr.statusCode = response.statusCode;
-      return callback(badStatusErr);
-    }
-    callback(null, true);
-  });
+    })
+    .set('User-Agent', 'StriderCD (http://stridercd.com)')
+    .end(function (err, res) {
+      if (err) return callback(err);
+      if (res.statusCode !== 201) {
+        var badStatusErr = new Error('Bad status code: ' + res.statusCode);
+        badStatusErr.statusCode = res.statusCode;
+        return callback(badStatusErr);
+      }
+      callback(null, true);
+    });
 }
 
 /**
@@ -148,18 +144,19 @@ function getFile(filename, ref, accessToken, owner, repo, done) {
  * @param {Object} q_params Object representing the query params to be added to GET request
  * @param {String} access_token OAuth2 access token
  * @param {Function} callback function(error, response, body)
+ * @param {Object} client An alternative superagent instance to use.
  */
 var get_oauth2 = module.exports.get_oauth2 = function (url, q_params, access_token, callback, client) {
-  client = client || request;
-  url += '?';
-  q_params.access_token = access_token;
-  url += qs.stringify(q_params);
+  // If the user provided a superagent instance, use that.
+  client = client || superagent;
+  // Construct the query. Allow the user to override the access_token through q_params.
+  var query = _.assign({}, {access_token : access_token}, q_params);
   console.debug('GET OAUTH2 URL:', url);
-  client.get({
-      url: url,
-      headers: {'user-agent': 'StriderCD (http://stridercd.com)'}
-    },
-    callback);
+  client
+    .get(url)
+    .query(query)
+    .set('User-Agent', 'StriderCD (http://stridercd.com)')
+    .end(callback);
 };
 
 /**
@@ -170,18 +167,19 @@ var get_oauth2 = module.exports.get_oauth2 = function (url, q_params, access_tok
  * @param {String} path API call URL path
  * @param {String} access_token OAuth2 access token
  * @param {Function} callback function(error, response, de-serialized json)
- * @param {String} params Additional query params
+ * @param {Object} client An alternative superagent instance to use.
  */
-var api_call = module.exports.api_call = function (path, access_token, callback, client, params) {
-  client = client || request;
+var api_call = module.exports.api_call = function (path, access_token, callback, client) {
+  // If the user provided a superagent instance, use that.
+  client = client || superagent;
   var url = GITHUB_API_ENDPOINT + path;
-  console.debug('API CALL:', url, params, access_token);
-  get_oauth2(url, {}, access_token, function (error, response, body) {
-    if (!error && response.statusCode == 200) {
+  console.debug('API CALL:', url, access_token);
+  get_oauth2(url, {}, access_token, function (error, res, body) {
+    if (!error && res.statusCode == 200) {
       var data = JSON.parse(body);
-      callback(null, response, data);
+      callback(null, res, data);
     } else {
-      callback(error, response, null);
+      callback(error, res, null);
     }
   }, client);
 };
@@ -224,9 +222,12 @@ var parse_link_header = module.exports.parse_link_header = function parse_link_h
  * @param {String} path API call URL path
  * @param {String} access_token OAuth2 access token
  * @param {Function} callback function(error, response, de-serialized json)
+ * @param {Object} client An alternative superagent instance to use.
  */
 var pageinated_api_call = module.exports.pageinated_api_call = function (path, access_token, callback, client) {
-  client = client || request;
+  // If the user provided a superagent instance, use that.
+  client = client || superagent;
+
   var base_url = GITHUB_API_ENDPOINT + path;
 
   if (!access_token) {
@@ -241,8 +242,8 @@ var pageinated_api_call = module.exports.pageinated_api_call = function (path, a
 
   function loop(uri, page) {
     console.debug('PAGINATED API CALL URL:', uri);
-    get_oauth2(uri, {per_page: 30, page: page}, access_token, function (error, response, body) {
-      if (!error && response.statusCode == 200) {
+    get_oauth2(uri, {per_page: 30, page: page}, access_token, function (error, res, body) {
+      if (!error && res.statusCode == 200) {
         var data;
         try {
           data = JSON.parse(body);
@@ -251,14 +252,14 @@ var pageinated_api_call = module.exports.pageinated_api_call = function (path, a
         }
         pages.push(data);
 
-        var link = response.headers['link'];
+        var link = res.headers['link'];
         var r;
         if (link) {
           r = parse_link_header(link);
         }
         // Stop condition: No link header or we think we just read the last page
         if (!link || r.next === undefined) {
-          callback(null, {data: _.flatten(pages), response: response});
+          callback(null, {data: _.flatten(pages), response: res});
         } else {
           // Request next page and continue
           var next_page = url.parse(r.next, true).query.page;
@@ -266,10 +267,10 @@ var pageinated_api_call = module.exports.pageinated_api_call = function (path, a
         }
       } else {
         if (!error) {
-          if (response.statusCode === 401 || response.statusCode === 403) {
+          if (res.statusCode === 401 || res.statusCode === 403) {
             return callback(new Error('Github app is not authorized. Did you revoke access?'))
           }
-          return callback(new Error('Status code is ' + response.statusCode + ' not 200. Body: ' + body))
+          return callback(new Error('Status code is ' + res.statusCode + ' not 200. Body: ' + body))
         } else {
           return callback(error, null);
         }
@@ -300,6 +301,7 @@ function getRepos(token, username, callback) {
   // needs callback(null, {groupname: [repo, ...], ...})
   // see strider-extension-loader for details
 
+  /* jshint -W064 */
   Step(
     function fetchReposAndOrgs() {
       // First fetch the user's repositories and organizations in parallel.
@@ -399,9 +401,9 @@ function getRepos(token, username, callback) {
       }
       var team_detail_requests = this.team_detail_requests;
       var group = this.group();
-      _.each(results, function (response) {
-        var team_id = response.request.uri.path.split('/');
-        if (response.request.uri.path.indexOf('/api/v3/') > -1) {
+      _.each(results, function (res) {
+        var team_id = res.request.uri.path.split('/');
+        if (res.request.uri.path.indexOf('/api/v3/') > -1) {
           // Github Enterprise url
           team_id = team_id[4];
         }
@@ -410,7 +412,7 @@ function getRepos(token, username, callback) {
           team_id = team_id[2];
         }
         var team_detail = team_detail_requests[parseInt(team_id, 10)];
-        if (response.statusCode === 204) {
+        if (res.statusCode === 204) {
           pageinated_api_call('/teams/' + team_id + '/repos', token, group());
         }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,9 +4,8 @@ var _ = require('lodash');
 var config = require('./config');
 var crypto = require('crypto');
 var keypair = require('ssh-keypair');
-var qs = require('querystring');
-var request = require('request');
 var step = require('step');
+var superagent = require('superagent');
 var url = require('url');
 var User = require('./models').User;
 
@@ -20,17 +19,19 @@ var GITHUB_API_ENDPOINT = 'https://api.github.com';
  * @param {Object} q_params Object representing the query params to be added to GET request
  * @param {String} access_token OAuth2 access token
  * @param {Function} callback function(error, response, body)
+ * @param {Object} client An alternative superagent instance to use.
  */
 var get_oauth2 = module.exports.get_oauth2 = function (url, q_params, access_token, callback, client) {
-  client = client || request;
-  url += '?';
-  q_params.access_token = access_token;
-  url += qs.stringify(q_params);
-  client.get({
-      url: url,
-      headers: {'user-agent': 'StriderCD (http://stridercd.com)'}
-    },
-    callback);
+  // If the user provided a superagent instance, use that.
+  client = client || superagent;
+  // Construct the query. Allow the user to override the access_token through q_params.
+  var query = _.assign({}, {access_token : access_token}, q_params);
+  console.debug('GET OAUTH2 URL:', url);
+  client
+    .get(url)
+    .query(query)
+    .set('User-Agent', 'StriderCD (http://stridercd.com)')
+    .end(callback);
 };
 
 /**
@@ -41,17 +42,19 @@ var get_oauth2 = module.exports.get_oauth2 = function (url, q_params, access_tok
  * @param {String} path API call URL path
  * @param {String} access_token OAuth2 access token
  * @param {Function} callback function(error, response, de-serialized json)
+ * @param {Object} client An alternative superagent instance to use.
  */
 var api_call = module.exports.api_call = function (path, access_token, callback, client) {
-  client = client || request;
+  // If the user provided a superagent instance, use that.
+  client = client || superagent;
   var url = GITHUB_API_ENDPOINT + path;
-  console.debug('github api_call(): path %s', path);
-  get_oauth2(url, {}, access_token, function (error, response, body) {
-    if (!error && response.statusCode == 200) {
+  console.debug('API CALL:', url, access_token);
+  get_oauth2(url, {}, access_token, function (error, res, body) {
+    if (!error && res.statusCode == 200) {
       var data = JSON.parse(body);
-      callback(null, response, data);
+      callback(null, res, data);
     } else {
-      callback(error, response, null);
+      callback(error, res, null);
     }
   }, client);
 };
@@ -93,9 +96,12 @@ var parse_link_header = module.exports.parse_link_header = function parse_link_h
  * @param {String} path API call URL path
  * @param {String} access_token OAuth2 access token
  * @param {Function} callback function(error, response, de-serialized json)
+ * @param {Object} client An alternative superagent instance to use.
  */
 var pageinated_api_call = module.exports.pageinated_api_call = function (path, access_token, callback, client) {
-  client = client || request;
+  // If the user provided a superagent instance, use that.
+  client = client || superagent;
+
   var base_url = GITHUB_API_ENDPOINT + path;
   console.debug('github pageinated_api_call(): path %s', path);
 
@@ -351,19 +357,20 @@ var save_repo_deploy_keys = module.exports.save_repo_deploy_keys = function (use
  * @param {String} title Title for key
  * @param {String} token OAuth2 access token
  * @param {Function} callback function(error, response, body)
+ * @param {Object} client An alternative superagent instance to use.
  */
 var add_deploy_key = module.exports.add_deploy_key = function (gh_repo_path, pubkey, title, token, callback, client) {
-  client = client || request;
+  client = client || superagent;
   var qpm = {access_token: token};
   var data = {title: title, key: pubkey};
-  var url = GITHUB_API_ENDPOINT + '/repos' + gh_repo_path + '/keys?' + qs.stringify(qpm);
+  var url = GITHUB_API_ENDPOINT + '/repos' + gh_repo_path + '/keys';
 
-  client.post({
-    url: url,
-    body: data,
-    json: true,
-    headers: {'user-agent': 'StriderCD (http://stridercd.com)'}
-  }, callback);
+  client
+    .post(url)
+    .query(qpm)
+    .send(data)
+    .set('User-Agent', 'StriderCD (http://stridercd.com)')
+    .end(callback);
 };
 
 /**
@@ -377,19 +384,20 @@ var add_deploy_key = module.exports.add_deploy_key = function (gh_repo_path, pub
  * @param {String} secret is the Webhook secret, which will be used to generate the HMAC-SHA1 header in the Github request.
  * @param {String} token OAuth2 access token
  * @param {Function} callback function(error, response, body)
+ * @param {Object} client An alternative superagent instance to use.
  */
 var set_push_hook = module.exports.set_push_hook = function (gh_repo_path, name, url, secret, token, callback, client) {
-  client = client || request;
+  client = client || superagent;
   var data = {name: name, active: true, config: {url: url, secret: secret}};
   var qpm = {access_token: token};
-  var post_url = GITHUB_API_ENDPOINT + '/repos' + gh_repo_path + '/hooks?' + qs.stringify(qpm);
+  var post_url = GITHUB_API_ENDPOINT + '/repos' + gh_repo_path + '/hooks';
 
-  client.post({
-    url: post_url,
-    body: data,
-    json: true,
-    headers: {'user-agent': 'StriderCD (http://stridercd.com)'}
-  }, callback);
+  client
+    .post(post_url)
+    .query(qpm)
+    .send(data)
+    .set('User-Agent', 'StriderCD (http://stridercd.com)')
+    .end(callback);
 };
 
 /**
@@ -400,9 +408,10 @@ var set_push_hook = module.exports.set_push_hook = function (gh_repo_path, name,
  * @param {String} gh_repo_path is "/<org or user>/<repo name>" e.g. "/BeyondFog/Strider". This doesn't add slashes, caller must get it right.
  * @param {String} token OAuth2 access token
  * @param {Function} callback function(error, response, body)
+ * @param {Object} client An alternative superagent instance to use.
  */
 var unset_push_hook = module.exports.unset_push_hook = function (gh_repo_path, token, callback, client) {
-  client = client || request;
+  client = client || superagent;
   var qpm = {access_token: token};
 
   console.debug('github.unset_push_hook() deleting Github webhooks for repo path %s', gh_repo_path);
@@ -423,12 +432,11 @@ var unset_push_hook = module.exports.unset_push_hook = function (gh_repo_path, t
         if (hook.config.url === strider_url) {
           console.debug('github.unset_push_hook() found hook: %j for repo %s, deleting',
             hook, gh_repo_path);
-          client.del({
-              url: GITHUB_API_ENDPOINT + '/repos' + gh_repo_path + '/hooks/' + hook.id + '?' + qs.stringify(qpm),
-              headers: {'user-agent': 'StriderCD (http://stridercd.com)'}
-            },
-            group()
-          );
+          client
+            .del(GITHUB_API_ENDPOINT + '/repos' + gh_repo_path + '/hooks/' + hook.id)
+            .query(qpm)
+            .set('User-Agent', 'StriderCD (http://stridercd.com)')
+            .end(group());
         }
       });
     },

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -14,10 +14,10 @@ module.exports = {
 };
 
 function makeJob(project, config) {
-  var now = new Date()
-    , deploy = false
-    , branch
-    , job
+  var now = new Date();
+  var deploy = false;
+  var branch;
+  var job;
 
   branch = project.branch(config.branch) || {active: true, mirror_master: true, deploy_on_green: false};
   if (!branch.active) return false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strider-github",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "description": "A github & github enterprise provider for strider",
   "main": "lib/index.js",
   "scripts": {
@@ -47,7 +47,6 @@
     "lodash": "^2.2.1",
     "passport": "~0.1.17",
     "passport-github": "jaredhanson/passport-github",
-    "request": "~2.27.0",
     "scmp": "0.0.2",
     "ssh-keypair": "~1.0.0",
     "step": "0.0.5",


### PR DESCRIPTION
This is a breaking change for code that possibly provides alternative client instances to exported functions that support that.
Previously, request instances were expected, now superagent instances are expected.