### PR TITLE
Store pull request number as job meta data

### DIFF
--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -119,7 +119,8 @@ function pullRequestJob(pr) {
         pull_request: {
           user: pr.head.repo.owner.login,
           repo: pr.head.repo.name,
-          sha: pr.head.sha
+          sha: pr.head.sha,
+          number: pr.number
         }
       }
     }


### PR DESCRIPTION
Allows for easy access to the pull request number. 
This is needed for more complex test scripts (especially useful in conjunction with strider-custom).

BTW: Alternatively, the number could be extracted from the "refs" url. However, I find this a little bit
hack-ish and unnecessarily complicated.