### PR TITLE
incorrect no. of args for superagent callback (request for comments)

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -47,6 +47,7 @@ function createHooks(reponame, url, secret, token, callback) {
     .set('User-Agent', 'StriderCD (http://stridercd.com)')
     .end(function (err, res) {
       if (err) return callback(err);
+
       if (res.statusCode !== 201) {
         var badStatusErr = new Error('Bad status code: ' + res.statusCode);
         badStatusErr.statusCode = res.statusCode;
@@ -73,7 +74,8 @@ function deleteHooks(reponame, url, token, callback) {
     .get(apiUrl)
     .set('Authorization', 'token ' + token)
     .set('User-Agent', 'StriderCD (http://stridercd.com)')
-    .end(function (res) { //CHECK: have a callback with the first param as err and process that err
+    .end(function (err, res) {
+      if(err) return callback(err);
       if (res.status > 300) {
         debug('Error getting hooks', res.status, res.text);
         return callback(res.status);
@@ -87,7 +89,8 @@ function deleteHooks(reponame, url, token, callback) {
             .del(hook.url)
             .set('Authorization', 'token ' + token)
             .set('User-Agent', 'StriderCD (http://stridercd.com)')
-            .end(function (res) { //CHECK: have a callback with the first param as err and process that err
+            .end(function (err, res) {
+              if(err) return next(new Error('Failed to delete webhook ' + hook.url + 'Error: ' + err));
               if (res.status !== 204) {
                 debug('bad status', res.status, hook.id, hook.url);
                 return next(new Error('Failed to delete a webhook: status for url ' + hook.url + ': ' + res.status));
@@ -127,7 +130,8 @@ function getFile(filename, ref, accessToken, owner, repo, done) {
   if (accessToken) {
     req = req.set('Authorization', 'token ' + accessToken);
   }
-  req.end(function (res) {  //CHECK: have a callback with the first param as err and process that err
+  req.end(function (err, res) {
+    if(err) return done(err, null);
     if (res.error) return done(res.error, null);
     if (!res.body.content) {
       return done();
@@ -176,11 +180,11 @@ var api_call = module.exports.api_call = function (path, access_token, callback,
   var url = GITHUB_API_ENDPOINT + path;
   debug('API CALL:', url, access_token);
   get_oauth2(url, {}, access_token, function (error, res) {
-    debug("We get an error from the API: " + error);
     if (!error && res.statusCode == 200) {
       var data = res.body;
       callback(null, res, data);
     } else {
+      debug("We get an error from the API: " + error);
       callback(error, res, null);
     }
   }, client);
@@ -245,7 +249,7 @@ var pageinated_api_call = module.exports.pageinated_api_call = function (path, a
   function loop(uri, page) {
     debug('PAGINATED API CALL URL:', uri);
     get_oauth2(uri, {per_page: 30, page: page}, access_token, function (error, res) {
-    debug("We get an error: " + error);
+
       if (!error && res.statusCode == 200) {
         var data;
         try {
@@ -389,8 +393,6 @@ function getRepos(token, username, callback) {
       });
       // For each Team with admin privs, test for membership
       var group = this.group();
-      debug("****************************************************************\nThis is: " + JSON.stringify(this, null, 4)); //CHECK: undefined
-      debug("****************************************************************\ngroup is: " + JSON.stringify(group, null, 4)); //CHECK: undefined
 
       var team_detail_requests = {};
       _.each(team_details, function (team_details) {
@@ -398,18 +400,9 @@ function getRepos(token, username, callback) {
           return;
         }
         team_detail_requests[team_details.id] = team_details;
-        var url = GITHUB_API_ENDPOINT + '/teams/' + team_details.id + '/members/' + username;
+        var url = '/teams/' + team_details.id + '/members/' + username;
         debug('TEAM DETAIL URL', url);
-        get_oauth2(url, {}, token, group()); //<------------------- this is a problem
-                                             //get_oauth sends this callback as it is to superagent
-                                             //superagent expects a callback that takes two arguments
-                                             //in the other places it works because we are sending group() as
-                                             //as a parameter to api_call or pageinated_api_call, and they are now correctly wrapping
-                                             //get_oauth, passing in a callback that expects two arguments
-                                             //if we were to replace this get_oauth2 call by a call to api_call,
-                                             //it would probably work as a hack, but the intention behind group()
-                                             //and this.group() is yet to be understood by me
-
+        api_call(url, token, group());
       });
       this.team_detail_requests = team_detail_requests;
     },

--- a/lib/api.js
+++ b/lib/api.js
@@ -6,6 +6,7 @@ var debug = require('debug')('strider-github:api');
 var Step = require('step');
 var superagent = require('superagent');
 var url = require('url');
+var util = require('util');
 
 var GITHUB_API_ENDPOINT = process.env.PLUGIN_GITHUB_API_ENDPOINT || 'https://api.github.com';
 
@@ -418,16 +419,9 @@ function getRepos(token, username, callback) {
 
       _.each(results, function (result) {
         var team_id = result.req.path.split('/');
-        if (result.req.path.indexOf('/api/v3/') > -1) {
-          // Github Enterprise url
-          team_id = team_id[4]; //TODO: need a github enterprise account for
-                                // this to be tested - does the path
-                                // really contain /api/v3?
-        }
-        else {
-          // Github url
-          team_id = team_id[2];
-        }
+        debug("We get the following repo path: " + util.inspect(result.req.path));
+        team_id = team_id[2];
+
         var team_detail = team_detail_requests[parseInt(team_id, 10)];
         if (result.statusCode === 204) {
           pageinated_api_call('/teams/' + team_id + '/repos', token, group());

--- a/lib/api.js
+++ b/lib/api.js
@@ -274,7 +274,7 @@ var pageinated_api_call = module.exports.pageinated_api_call = function (path, a
           if (res.statusCode === 401 || res.statusCode === 403) {
             return callback(new Error('Github app is not authorized. Did you revoke access?'))
           }
-          return callback(new Error('Status code is ' + res.statusCode + ' not 200. Body: ' + body))
+          return callback(new Error('Status code is ' + res.statusCode + ' not 200. Body: ' + res.body))
         } else {
           debug("We did get an error from the API " + error);
           return callback(error, null);
@@ -307,6 +307,7 @@ function getRepos(token, username, callback) {
   // see strider-extension-loader for details
 
   /* jshint -W064 */
+  /* jshint -W040 */
   Step(
     function fetchReposAndOrgs() {
       // First fetch the user's repositories and organizations in parallel.

--- a/lib/api.js
+++ b/lib/api.js
@@ -415,18 +415,21 @@ function getRepos(token, username, callback) {
       }
       var team_detail_requests = this.team_detail_requests;
       var group = this.group();
-      _.each(results, function (res) {
-        var team_id = res.request.uri.path.split('/');
-        if (res.request.uri.path.indexOf('/api/v3/') > -1) {
+
+      _.each(results, function (result) {
+        var team_id = result.req.path.split('/');
+        if (result.req.path.indexOf('/api/v3/') > -1) {
           // Github Enterprise url
-          team_id = team_id[4];
+          team_id = team_id[4]; //TODO: need a github enterprise account for
+                                // this to be tested - does the path
+                                // really contain /api/v3?
         }
         else {
           // Github url
           team_id = team_id[2];
         }
         var team_detail = team_detail_requests[parseInt(team_id, 10)];
-        if (res.statusCode === 204) {
+        if (result.statusCode === 204) {
           pageinated_api_call('/teams/' + team_id + '/repos', token, group());
         }
 
@@ -438,6 +441,7 @@ function getRepos(token, username, callback) {
         debug('get_github_repos(): Error with team repos request: %s', err);
         return callback(err);
       }
+
       _.each(results, function (result) {
         if (result && result.data) {
           _.each(result.data, function (team_repo) {
@@ -459,6 +463,7 @@ function getRepos(token, username, callback) {
           });
         }
       });
+
       // Sometimes we can get multiple copies of the same team repo, so we uniq it
       team_repos = _.uniq(team_repos, false, function (item) {
         return item.id;

--- a/lib/api.js
+++ b/lib/api.js
@@ -73,7 +73,7 @@ function deleteHooks(reponame, url, token, callback) {
     .get(apiUrl)
     .set('Authorization', 'token ' + token)
     .set('User-Agent', 'StriderCD (http://stridercd.com)')
-    .end(function (res) {
+    .end(function (res) { //CHECK: have a callback with the first param as err and process that err
       if (res.status > 300) {
         debug('Error getting hooks', res.status, res.text);
         return callback(res.status);
@@ -87,7 +87,7 @@ function deleteHooks(reponame, url, token, callback) {
             .del(hook.url)
             .set('Authorization', 'token ' + token)
             .set('User-Agent', 'StriderCD (http://stridercd.com)')
-            .end(function (res) {
+            .end(function (res) { //CHECK: have a callback with the first param as err and process that err
               if (res.status !== 204) {
                 debug('bad status', res.status, hook.id, hook.url);
                 return next(new Error('Failed to delete a webhook: status for url ' + hook.url + ': ' + res.status));
@@ -127,7 +127,7 @@ function getFile(filename, ref, accessToken, owner, repo, done) {
   if (accessToken) {
     req = req.set('Authorization', 'token ' + accessToken);
   }
-  req.end(function (res) {
+  req.end(function (res) {  //CHECK: have a callback with the first param as err and process that err
     if (res.error) return done(res.error, null);
     if (!res.body.content) {
       return done();
@@ -152,6 +152,7 @@ var get_oauth2 = module.exports.get_oauth2 = function (url, q_params, access_tok
   // Construct the query. Allow the user to override the access_token through q_params.
   var query = _.assign({}, {access_token : access_token}, q_params);
   debug('GET OAUTH2 URL:', url);
+  debug('Inside get_oauth2: Callback type: ' + typeof callback + ' Number of arguments expected by: ' + callback.length);
   client
     .get(url)
     .query(query)
@@ -173,10 +174,11 @@ var api_call = module.exports.api_call = function (path, access_token, callback,
   // If the user provided a superagent instance, use that.
   client = client || superagent;
   var url = GITHUB_API_ENDPOINT + path;
-  debug('API CALL:', url, params, access_token);
-  get_oauth2(url, {}, access_token, function (error, res, body) {
+  debug('API CALL:', url, access_token);
+  get_oauth2(url, {}, access_token, function (error, res) {
+    debug("We get an error from the API: " + error);
     if (!error && res.statusCode == 200) {
-      var data = JSON.parse(body);
+      var data = res.body;
       callback(null, res, data);
     } else {
       callback(error, res, null);
@@ -242,11 +244,12 @@ var pageinated_api_call = module.exports.pageinated_api_call = function (path, a
 
   function loop(uri, page) {
     debug('PAGINATED API CALL URL:', uri);
-    get_oauth2(uri, {per_page: 30, page: page}, access_token, function (error, res, body) {
+    get_oauth2(uri, {per_page: 30, page: page}, access_token, function (error, res) {
+    debug("We get an error: " + error);
       if (!error && res.statusCode == 200) {
         var data;
         try {
-          data = JSON.parse(body);
+          data = res.body;
         } catch (e) {
           return callback(e, null);
         }
@@ -267,11 +270,13 @@ var pageinated_api_call = module.exports.pageinated_api_call = function (path, a
         }
       } else {
         if (!error) {
+          debug("We did not get an error, but status code was: " + res.statusCode);
           if (res.statusCode === 401 || res.statusCode === 403) {
             return callback(new Error('Github app is not authorized. Did you revoke access?'))
           }
           return callback(new Error('Status code is ' + res.statusCode + ' not 200. Body: ' + body))
         } else {
+          debug("We did get an error from the API " + error);
           return callback(error, null);
         }
       }
@@ -343,13 +348,16 @@ function getRepos(token, username, callback) {
     },
     function fetchTeamDetails(err, results) {
       if (err) {
+        debug(err.message);
+        debug(err.name);
+        debug(err.stack);
         debug('get_github_repos() - Error fetching Org Teams response - %s', err);
         return callback(err);
       }
       var teams = [];
       _.each(results, function (result) {
         try {
-          var team_data = JSON.parse(result.body);
+          var team_data = result.body;
           _.each(team_data, function (t) {
             teams.push(t);
           });
@@ -372,7 +380,7 @@ function getRepos(token, username, callback) {
       var team_details = [];
       _.each(results, function (result) {
         try {
-          var td = JSON.parse(result.body);
+          var td = result.body;
           team_details.push(td);
         } catch (e) {
           debug('get_github_repos(): Error parsing JSON in detail team response - %s', e);
@@ -380,6 +388,9 @@ function getRepos(token, username, callback) {
       });
       // For each Team with admin privs, test for membership
       var group = this.group();
+      debug("****************************************************************\nThis is: " + JSON.stringify(this, null, 4)); //CHECK: undefined
+      debug("****************************************************************\ngroup is: " + JSON.stringify(group, null, 4)); //CHECK: undefined
+
       var team_detail_requests = {};
       _.each(team_details, function (team_details) {
         if (team_details.permission != 'admin') {
@@ -388,7 +399,16 @@ function getRepos(token, username, callback) {
         team_detail_requests[team_details.id] = team_details;
         var url = GITHUB_API_ENDPOINT + '/teams/' + team_details.id + '/members/' + username;
         debug('TEAM DETAIL URL', url);
-        get_oauth2(url, {}, token, group());
+        get_oauth2(url, {}, token, group()); //<------------------- this is a problem
+                                             //get_oauth sends this callback as it is to superagent
+                                             //superagent expects a callback that takes two arguments
+                                             //in the other places it works because we are sending group() as
+                                             //as a parameter to api_call or pageinated_api_call, and they are now correctly wrapping
+                                             //get_oauth, passing in a callback that expects two arguments
+                                             //if we were to replace this get_oauth2 call by a call to api_call,
+                                             //it would probably work as a hack, but the intention behind group()
+                                             //and this.group() is yet to be understood by me
+
       });
       this.team_detail_requests = team_detail_requests;
     },

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,8 @@ var User = require('./models').User;
 
 var GITHUB_API_ENDPOINT = 'https://api.github.com';
 
+/* jshint -W040 */
+
 /**
  * get_oauth2()
  *

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,7 @@ var GITHUB_API_ENDPOINT = 'https://api.github.com';
  * @param {Object} client An alternative superagent instance to use.
  */
 var get_oauth2 = module.exports.get_oauth2 = function (url, q_params, access_token, callback, client) {
+  console.debug('OAUTH2 CALLBACK LENGTH:', callback.length);
   // If the user provided a superagent instance, use that.
   client = client || superagent;
   // Construct the query. Allow the user to override the access_token through q_params.
@@ -50,9 +51,9 @@ var api_call = module.exports.api_call = function (path, access_token, callback,
   client = client || superagent;
   var url = GITHUB_API_ENDPOINT + path;
   debug('github api_call(): path %s', path);
-  get_oauth2(url, {}, access_token, function (error, res, body) {
+  get_oauth2(url, {}, access_token, function (error, res) {
     if (!error && res.statusCode == 200) {
-      var data = JSON.parse(body);
+      var data = res.body;
       callback(null, res, data);
     } else {
       callback(error, res, null);
@@ -117,11 +118,11 @@ var pageinated_api_call = module.exports.pageinated_api_call = function (path, a
   var pages = [];
 
   function loop(uri, page) {
-    get_oauth2(uri, {per_page: 30, page: page}, access_token, function (error, response, body) {
+    get_oauth2(uri, {per_page: 30, page: page}, access_token, function (error, response) {
       if (!error && response.statusCode == 200) {
         var data;
         try {
-          data = JSON.parse(body);
+          data = response.body;
         } catch (e) {
           return callback(e, null);
         }
@@ -142,7 +143,7 @@ var pageinated_api_call = module.exports.pageinated_api_call = function (path, a
         }
       } else {
         if (!error) {
-          return callback('Status code is ' + response.statusCode + ' not 200. Body: ' + body)
+          return callback('Status code is ' + response.statusCode + ' not 200. Body: ' + response.body)
         } else {
           return callback(error, null);
         }
@@ -210,7 +211,7 @@ module.exports.get_github_repos = function (user, callback) {
       _.each(results, function (result) {
         try {
           debug('For Organizations: %s', result.request.uri.path.split('/')[2]);
-          var team_data = JSON.parse(result.body);
+          var team_data = result.body;
           _.each(team_data, function (t) {
             debug('Team details: %j', t);
             teams.push(t);
@@ -235,7 +236,7 @@ module.exports.get_github_repos = function (user, callback) {
       var team_details = [];
       _.each(results, function (result) {
         try {
-          var td = JSON.parse(result.body);
+          var td = result.body;
           team_details.push(td);
         } catch (e) {
           debug('get_github_repos(): Error parsing JSON in detail team response - %s', e);

--- a/test/test_api.js
+++ b/test/test_api.js
@@ -1,6 +1,6 @@
 
 var expect = require('expect.js')
-  , api = require('../lib/api')
+  , api = require('../lib/api');
 
 describe('github api', function () {
   describe('getFile', function () {

--- a/test/test_webhooks.js
+++ b/test/test_webhooks.js
@@ -42,7 +42,6 @@ describe('webhooks', function () {
       it('should work', function () {
         var fx = require('./sample_pull_request.json')
           , config = lib.pullRequestJob(fx.pull_request, fx.action)
-
         expect(config).to.eql({
           branch: 'master',
           deploy: false,
@@ -51,7 +50,8 @@ describe('webhooks', function () {
               pull_request: {
                 user: 'jaredly',
                 repo: 'petulant-wookie',
-                sha: 'f65ac3101a45bb9408c0459805b496cb73ae2d5f'
+                sha: 'f65ac3101a45bb9408c0459805b496cb73ae2d5f',
+                number: 1
               }
             }
           },


### PR DESCRIPTION
The plugin was failing to fetch the repos when configuring a github account for the first time OR when trying to do a "Refresh Account" from the web page.

There were a couple of issues here:
a. JSON.parse was not necessary since superagent returns a parsed object if we receive json.
https://visionmedia.github.io/superagent/#parsing-response%20bodies

b. We get a object parsed from JSON where we are expecting an error.

   We were passing a callback with three arguments to superagent in .end(callback). For example in -
   get_oauth2(uri, {per_page: 30, page: page},
          access_token, function (error, response, body) {
                             //   ^ here, we should send
                             //   only error and response
  //In any case superagent puts the body inside response.body
  //https://visionmedia.github.io/superagent/

  If we DO NOT pass in a callback with TWO arguments, ===> superagent does not bother to see that we are sending it a callback with THREE arguments, and instead, it sends us the RESPONSE as the only/first argument, which we expect to be an error in the callback. <===

  This may be verified by looking at `superagent/lib/node/index.js` around line 623 - (debugs added)

       Request.prototype.callback = function(err, res){
         debug('When calling the callback - err is ' + JSON.stringify(err, null, 4));
         var fn = this._callback;
         debug("And the number of arguments the callback expects is: " + fn.length );
         this.clearTimeout();
         if (this.called) return console.warn('double callback!');
         this.called = true;
         if (2 == fn.length) return fn(err, res);//<====== we want this to be true
         if (err) return this.emit('error', err);
         debug("Here, we are sending the first parameter to the callback as the response, " +
	       "but GOTCHA - our callback thinks the first param is an error and THROWS!");
         fn(res);
       };

c. Still need to understand the presence of this.group and group() as present in the comments in the code.
   The reason why it fails near `get_github_repos(): Error with admin team memberships: [object Object]` is because, the previous function in the "Step" has a call to `get_oauth2(url, {}, token, group())` - which basically sends the last parameter as it is to superagent. And thus we have an object with data received from the API, which we think is an err.

