### PR TITLE
sendJob is expected to return a true value

### DIFF
--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -257,6 +257,7 @@ function receiveWebhook(emitter, req, res) {
 
   function sendJob(job) {
     emitter.emit('job.prepare', job);
+    return true;
   }
 }
 


### PR DESCRIPTION
Otherwise, we are logging a message saying
that branch was not found or active. (Even
if the job was created successfully.)

This is the same as the issue in the gitlab
provider:
 https://github.com/Strider-CD/strider-gitlab/issues/30