### PR TITLE
Add pull request body to pull request meta information

### DIFF
--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -125,7 +125,8 @@ function pullRequestJob(pr) {
           user: pr.head.repo.owner.login,
           repo: pr.head.repo.name,
           sha: pr.head.sha,
-          number: pr.number
+          number: pr.number,
+          body: pr.body
         }
       }
     }


### PR DESCRIPTION
I'm adding the `body` key to the `plugin_data` here so that it can be made available to other plugins.