### PR TITLE
Use strider_server_name instead of SERVER_NAME for hostname.

### DIFF
--- a/lib/webapp.js
+++ b/lib/webapp.js
@@ -9,7 +9,7 @@ var webhooks = require('./webhooks');
 
 module.exports = {
   appConfig: {
-    hostname:    process.env.SERVER_NAME || 'http://localhost:3000',
+    hostname:    process.env.strider_server_name || 'http://localhost:3000',
     // you only need to override these if you are connecting to github enterprise
     // if you are on github enterprise, you'll need to create a new app: http://github.whatever.com/applications/new
     appId:       process.env.PLUGIN_GITHUB_APP_ID || 'a3af4568e9d8ca4165fe',


### PR DESCRIPTION
Solves issue https://github.com/Strider-CD/strider-github/issues/55#issuecomment-171649444. The problem is that Strider is changing the env variable `SERVER_NAME` to `strider_server_name` [here](https://github.com/Strider-CD/strider/blob/e29f0f0466ec1dcbde60460e3d4159096ca61a5c/lib/libconfig.js#L103).