### PR TITLE
Improved error when adding project without admin rights.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,5 @@ of the following are set. On GitHub Enterprise, log in to the profile you are tr
 
 - Make sure your github profile has a public email set
   * Go to https://github.com/settings/profile and select an email under "Public email".
+- Make sure you have admin rights on the projects before adding them,
+since strider will need to create webhooks for the integration to work.

--- a/lib/api.js
+++ b/lib/api.js
@@ -50,8 +50,14 @@ function createHooks(reponame, url, secret, token, callback) {
     .end(function (err, res) {
       if (err) return callback(err);
 
+      var badStatusErr;
+      if (res.statusCode === 404) {
+        badStatusErr = new Error('Cannot create webhooks; are you sure you have admin rights?');
+        badStatusErr.statusCode = res.statusCode;
+        return callback(badStatusErr);
+      }
       if (res.statusCode !== 201) {
-        var badStatusErr = new Error('Bad status code: ' + res.statusCode);
+        badStatusErr = new Error('Bad status code: ' + res.statusCode);
         badStatusErr.statusCode = res.statusCode;
         return callback(badStatusErr);
       }

--- a/lib/api.js
+++ b/lib/api.js
@@ -56,7 +56,7 @@ function createHooks(reponame, url, secret, token, callback) {
         badStatusErr.statusCode = res.statusCode;
         return callback(badStatusErr);
       }
-      if (res.statusCode !== 201) {
+      else if (res.statusCode !== 201) {
         badStatusErr = new Error('Bad status code: ' + res.statusCode);
         badStatusErr.statusCode = res.statusCode;
         return callback(badStatusErr);


### PR DESCRIPTION
When trying to add a project where you don't have admin rights, right now the error message is:

    Error creating project for repo owner/project:
    {"results":[],"status":"error","errors":[{"code":500,
    "reason":"Failed to setup repo: Bad status code: 404"}]}

Now should show:

    "reason":"Failed to setup repo: Cannot create webhooks; are you sure you have admin rights?"}]}

Also added a known issue to the `README.md`.

Should solve issue https://github.com/Strider-CD/strider-github/issues/60.