### PR TITLE
Fix bug when GitHub does not send some data.

### DIFF
--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -49,6 +49,12 @@ function startFromCommit(project, payload, send) {
   var config = pushJob(payload);
   var lastCommit = payload.commits[payload.commits.length - 1];
 
+  if (!lastCommit) {
+    lastCommit = {};
+  }
+  if (!lastCommit.message) {
+    lastCommit.message = 'No message.';
+  }
   if (lastCommit.message.indexOf('[skip ci]') > -1) {
     return {skipCi: true};
   }
@@ -159,6 +165,16 @@ function pushJob(payload) {
     ref = {
       fetch: payload.ref
     }
+  }
+  if (!commit) {
+    commit = {};
+  }
+  if (!commit.author) {
+    commit.author = {
+      name: 'No name',
+      username: 'No login',
+      email: 'noemail@github.com'
+    };
   }
   trigger = {
     type: 'commit',


### PR DESCRIPTION
When GitHow throws a webhook like `Created` or `Deleted` does not send necessary info and there are errors in this plugin like commented in #67 and others. This PR solves that.